### PR TITLE
Hoist type generation from playground to package

### DIFF
--- a/package/virtual.d.ts
+++ b/package/virtual.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../playground/.astro/types.d.ts" />


### PR DESCRIPTION
This allows types generated inside the playground, like content collections, to work properly for authors